### PR TITLE
Add a 'tag' option to customize generated HTML tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # vanilla-nested
+
 Rails dynamic nested forms using vanilla JS
 
 Similar to cocoon, but with no jquery dependency!
 
 # Installation
+
 Just add it to your gemfile
 
 ```ruby
@@ -13,22 +15,28 @@ gem 'vanilla_nested'
 
 If you are using Sprockets, just require the js
 
-```//= require vanilla_nested```
+```
+//= require vanilla_nested
+```
 
 If you use Webpacker, add the package also (gem is required for the helper methods) using:
 
-```yarn add arielj/vanilla-nested```
+```sh
+yarn add arielj/vanilla-nested
+```
 
 And then use it in your application.js as:
 
-```import 'vanilla-nested'```
+```js
+import "vanilla-nested";
+```
 
 # Update
 
 To update the gem use either:
 
 ```
-gem update vanilla_nested # if using the gem from rubygems
+gem update vanilla_nested # if using the gem from RubyGems
 
 # or
 
@@ -45,7 +53,7 @@ yarn upgrade vanilla-nested
 
 # Usage
 
-``` HTML+ERB
+```HTML+ERB
 # orders/_order_item_fields.html.erb
 <div class="wrapper-div">
   <%= form.text_field :attr1 %>
@@ -54,7 +62,7 @@ yarn upgrade vanilla-nested
 </div>
 ```
 
-``` HTML+ERB
+```HTML+ERB
 # order/form.html.erb
 <%= form_for product do |form| %>
   <%= form.text_field :attr %>
@@ -69,41 +77,53 @@ yarn upgrade vanilla-nested
 ```
 
 Note that:
+
 - `link_to_remove_nested` receives the nested form as a parameter, it adds a hidden `[_destroy]` field
 - `link_to_add_nested` expects the form builder, the name of the association and the selector of the container where the gem will insert the new fields
 
 # Customizing link_to_add_nested
+
 #### Link text
+
 The default value is `Add <name of the associated model>`, but it can be changed using the parameter `link_text`:
 
-``` Ruby
+```Ruby
 link_to_add_nested(form, :order_items, '#order-items', link_text: I18n.t(:some_key))
 ```
+
 This way you can, for example, internationalize the text.
 
 #### Link classes
+
 By default, the link to add new fields has the class `vanilla-nested-add` which is required, but you can add more classes passing a string:
-``` Ruby
+
+```Ruby
 link_to_add_nested(form, :order_items, '#order-items', link_classes: 'btn btn-primary')
 ```
+
 This way you can style the link with no need of targeting the specific vanilla nested class.
 
 #### Insert position
-By default, new fields are appended to the container, you can chage that with the `insert_method` option. For now, only `:append` and `:prepend` are supported:
-``` Ruby
+
+By default, new fields are appended to the container, you can change that with the `insert_method` option. For now, only `:append` and `:prepend` are supported:
+
+```Ruby
 link_to_add_nested(form, :order_items, '#order-items', insert_method: :prepend)
 ```
 
 #### Partial name
-The default partial's name is infered using the association's class name. If your Order has_many :order_items and the class of those items is OrderItem, then the infered name is `order_item_fields`. You can use any partial name you like, though:
-``` Ruby
+
+The default partial's name is inferred using the association's class name. If your Order has_many :order_items and the class of those items is OrderItem, then the inferred name is `order_item_fields`. You can use any partial name you like, though:
+
+```Ruby
 link_to_add_nested(form, :order_items, '#order-items', partial: 'my_partial')
 ```
 
 #### Form variable used in the partial
+
 `link_to_add_nested` needs to render an empty template in order to later append/prepend it. To do that, it passes the form as a local variable. If your partial uses `form`, you don't have to do anything, but if you using another variable name, just customize it here.
 
-``` HTML+ERB
+```HTML+ERB
 # orders/_order_item_fields.html.erb
 <div class="wrapper-div">
   <%= ff.text_field :attr1 %>
@@ -112,11 +132,20 @@ link_to_add_nested(form, :order_items, '#order-items', partial: 'my_partial')
 </div>
 ```
 
-``` Ruby
+```Ruby
 link_to_add_nested(form, :order_items, '#order-items', partial_form_variable: :ff)
 ```
 
+#### Tag
+
+The HTML tag that will be generated. An `<a>` tag by default.
+
+```Ruby
+link_to_add_nested(form, :order_items, '#order-items', tag: 'span')
+```
+
 #### Link content
+
 If you need html content, you can use a block:
 
 ```erb
@@ -125,16 +154,18 @@ If you need html content, you can use a block:
 <% end %>
 ```
 
-
 # Customizing link_to_remove_nested
+
 #### Link text
+
 The default value is `"X"`, but it can be changed using the parameter `link_text`:
 
-``` Ruby
+```Ruby
 link_to_remove_nested(form, link_text: "remove")
 ```
 
 #### Link content
+
 If you need html content, you can use a block:
 
 ```erb
@@ -144,16 +175,20 @@ If you need html content, you can use a block:
 ```
 
 #### Link classes
+
 By default, the link to remove fields has the class `vanilla-nested-remove` which is required, but you can add more classes passing a space separated string:
-``` Ruby
+
+```Ruby
 link_to_remove_nested(form, link_classes: 'btn btn-primary')
 ```
+
 This way you can style the link with no need of targeting the specific vanilla nested class.
 
 #### Fields wrapper
+
 By default, the link to remove the fields assumes it's a direct child of the wrapper of the fields. You can customize this if you can't make it a direct child.
 
-``` HTML+ERB
+```HTML+ERB
 # orders/_order_item_fields.html.erb
 <div class="wrapper-div">
   <fieldset>
@@ -163,92 +198,113 @@ By default, the link to remove the fields assumes it's a direct child of the wra
   <span><%= link_to_remove_nested(ff, fields_wrapper_selector: 'wrapper-div') # if we don't set this, it will only hide the span %></span>
 </div>
 ```
+
 Note that:
-* The link MUST be a descendant of the fields wrapper, it may not be a direct child, but the look up of the wrapper uses javascript's `closest()` method, so it looks on the ancestors.
-* Since this uses javascript's `closest()`, there is no IE supported (https://caniuse.com/#search=closest). You may want to add a polyfill or define the method manually if you need to support it.
+
+- The link MUST be a descendant of the fields wrapper, it may not be a direct child, but the look up of the wrapper uses JavaScript's `closest()` method, so it looks on the ancestors.
+- Since this uses JavaScript's `closest()`, there is no IE supported (https://caniuse.com/#search=closest). You may want to add a polyfill or define the method manually if you need to support it.
+
+#### Tag
+
+The HTML tag that will be generated. An `<a>` tag by default.
+
+```Ruby
+link_to_remove_nested(ff, tag: 'p')
+```
 
 #### Undoing
+
 You can tell the plugin to add an "undo" link right after removing the fields (as a direct child of the fields wrapper! this is not customizable!).
 
-``` Ruby
+```Ruby
 link_to_remove_nested(ff, undo_link_timeout: 2000, undo_link_text: I18n.t('undo_remove_fields'), undo_link_classes: 'btn btn-secondary')
 ```
 
 Options are:
-* `undo_link_timeout`: miliseconds, greater than 0 to turn the feature on, default: `nil`
-* `undo_link_text`: string with the text of the link, great for internationalization, default: `'Undo'`
-* `undo_link_classes`: space separated string, default: `''`
+
+- `undo_link_timeout`: milliseconds, greater than 0 to turn the feature on, default: `nil`
+- `undo_link_text`: string with the text of the link, great for internationalization, default: `'Undo'`
+- `undo_link_classes`: space separated string, default: `''`
 
 # Events
+
 There are some events that you can listen to add custom callbacks on different moments. All events bubbles up the dom, so you can listen for them on any ancestor.
 
 #### 'vanilla-nested:fields-added'
+
 Triggered right after the fields wrapper was inserted on the container.
 
-``` Javascript
+```Javascript
   document.addEventListener('vanilla-nested:fields-added', function(e){
     // e.type == 'vanilla-nested:fields-added'
     // e.target == container div of the fields
-    // e.detail.triggerdBy == the "add" link
+    // e.detail.triggeredBy == the "add" link
     // e.detail.added == the fields wrapper just inserted
   })
 ```
 
 #### 'vanilla-nested:fields-limit-reached'
+
 Triggered right after the fields wrapper was inserted on the container if the current count is >= limit, where limit is the value configured on the model: `accepts_nested_attributes_for :assoc, limit: 5`. You can listen to this event to disable the "add" link for example, or to show a warning.
 
-``` Javascript
+```Javascript
   document.addEventListener('vanilla-nested:fields-limit-reached', function(e){
     // e.type == 'vanilla-nested:fields-added'
     // e.target == container div of the fields
-    // e.detail.triggerdBy == the "add" link
+    // e.detail.triggeredBy == the "add" link
   })
 ```
 
 #### 'vanilla-nested:fields-removed'
+
 Triggered when the fields wrapper if fully hidden (aka ""removed""), that is: after clicking the "remove" link with no timeout OR after the timeout finished.
 
-``` Javascript
+```Javascript
   document.addEventListener('vanilla-nested:fields-removed', function(e){
     // e.type == 'vanilla-nested:fields-removed'
     // e.target == fields wrapper ""removed""
-    // e.detail.triggerdBy == the "remove" link if no undo action, the 'undo' link if it was triggered by the timeout })
+    // e.detail.triggeredBy == the "remove" link if no undo action, the 'undo' link if it was triggered by the timeout })
 ```
 
 #### 'vanilla-nested:fields-hidden'
+
 Triggered when the fields wrapper if hidden with an undo option.
 
-``` Javascript
+```Javascript
   document.addEventListener('vanilla-nested:fields-hidden', function(e){
     // e.type == 'vanilla-nested:fields-hidden'
     // e.target == fields wrapper hidden
-    // e.detail.triggerdBy == the "remove" link
+    // e.detail.triggeredBy == the "remove" link
   })
 ```
 
 > **Remove vs Hidden**
 >
 > Behind the scene, the wrapper is never actually removed, because we need to send the `[_destroy]` parameter. But there are 2 different stages when removing it.
-> * If there's no "undo" action configured, the wrapped is set to `display: none` and considered "removed".
-> * If you use the "undo" feature, first the children of the wrapper are hidden (triggering the `hidden` event) and then, after the timeout passes, the wrapper is set to `display: none` (triggering the `removed` event).
+>
+> - If there's no "undo" action configured, the wrapped is set to `display: none` and considered "removed".
+> - If you use the "undo" feature, first the children of the wrapper are hidden (triggering the `hidden` event) and then, after the timeout passes, the wrapper is set to `display: none` (triggering the `removed` event).
 
 #### 'vanilla-nested:fields-hidden-undo'
+
 Triggered when the user undo the removal using the "undo" link.
 
-``` Javascript
+```Javascript
   document.addEventListener('vanilla-nested:fields-hidden-undo', function(e){
     // e.type == 'vanilla-nested:fields-hidden-undo'
     // e.target == fields wrapper unhidden
-    // e.detail.triggerdBy == the "undo" link
+    // e.detail.triggeredBy == the "undo" link
   })
 ```
 
 ## Using Webpacker
+
 For now, if you want to use this with webpacker, download the vanilla_nested.js file, put in inside `app/javascript` folder and import it on your `application.js` using `import '../vanilla_nested.js'`.
 
 ## Testing
 
 You can run the tests following these commands:
+
 - cd test/VanillaNestedTests # move to the rails app dir
 - bin/setup # install bundler, gems and yarn packages
 - rails test # unit tests
@@ -257,49 +313,61 @@ You can run the tests following these commands:
 # Changes from 1.0.0 to 1.1.0
 
 #### Change the method to infere the name of the partial
+
 Before, it used `SomeClass.name.downcase`, this created a problem for classes with more than one word:
+
 - User => 'user_fields'
 - SomeClass => 'someclass_fields'
 
 Now it uses `SomeClass.name.underscore`:
+
 - User => 'user_fields'
 - SomeClass => 'some_class_fields'
 
 If you used the old version, you'll need to change the partial name or provide the old name as the `partial:` argument.
 
-#### Fix some Rubocop style suggestions
+#### Fix some RuboCop style suggestions
+
 Mostly single/double quotes, spacing, etc.
 
 #### Added some Solagraph related doc for the view helpers
+
 Just so Solargraph plugins on editors like VS-Code can give you some documentation.
 
 #### Added some documentation on the code
+
 Mostly on the javascript code
 
 #### Added node module config
+
 So it can be used as a node module using yarn to integrate it using webpacker.
 
 # Changes from 1.1.0 to 1.2.0
 
 #### New event for the "limit" option of `accepts_nested_attributes_for`
+
 You can listen to the `vanilla-nested:fields-limit-reached` event that will fire when container has more or equals the amount of children than the `limit` option set on the `accepts_nested_attributes_for` configuration.
 
 # Changes from 1.2.0 to 1.2.1
 
 #### Removed "onclick" attribute for helpers and add event listeners within js
+
 If you were using webpacker, remember to replace the vanilla_nested.js file in your app/javascript folder
 
 # Changes from 1.2.1 to 1.2.2
 
 #### Added "link_classes" option to "link_to_remove_nested"
+
 You can set multiple classes for the "X" link
 
 #### Added a "link_content" block parameter for both link helpers
+
 You can pass a block to use as the content for the add and remove links
 
 # Changes from 1.2.2 to 1.2.3
 
 #### Fix using nested html elements as the content for buttons
+
 There was an error when using the helpers with things like:
 
 ```erb
@@ -317,6 +385,5 @@ Play nicely with Turbolinks' `turbolinks:load` event.
 # Changes from 1.2.4 to 1.2.5
 
 License change from GPL to MIT
-
 
 > Remember to update both gem and package https://github.com/arielj/vanilla-nested/tree/master#update

--- a/lib/vanilla_nested/view_helpers.rb
+++ b/lib/vanilla_nested/view_helpers.rb
@@ -4,14 +4,15 @@ module VanillaNested
   module ViewHelpers
     # @param form [FormBuild] builder on a "form_for" block
     # @param association [Symbol] name of the association
-    # @param container_selector [String] selector of the element to inser the fields
+    # @param container_selector [String] selector of the element to insert the fields
     # @param link_text [String, nil] text to use for the link tag
     # @param link_classes [String] space separated classes for the link tag
     # @param insert_method [:append, :prepend] tells javascript if the new fields should be appended or prepended to the container
     # @param partial_form_variable [String, Symbol] name of the variable that represents the form builder inside the fields partial
+    # @param tag [String] HTML tag to use for the html generated, defaults to and `a` tag
     # @param link_content [Block] block of code for the link content
     # @return [String] link tag
-    def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, &link_content)
+    def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, tag: 'a', &link_content)
       association_class = form.object.class.reflections[association.to_s].klass
       object = association_class.new
 
@@ -35,11 +36,12 @@ module VanillaNested
       nested_options = form.object.class.nested_attributes_options[association.to_sym]
       data['limit'] = nested_options[:limit] if nested_options[:limit]
 
-      if block_given?
-        link_to '#', class: classes, data: data, &link_content
-      else
-        text = link_text || "Add #{association_class.model_name}"
-        link_to text, '#', class: classes, data: data
+      content_tag(tag, class: classes, data: data) do
+        if block_given?
+          yield link_content
+        else
+          link_text || "Add #{association_class.model_name}"
+        end
       end
     end
 
@@ -50,9 +52,10 @@ module VanillaNested
     # @param undo_link_text [String] text to show as "undo"
     # @param undo_link_classes [String] space separated list of classes for the "undo" link
     # @param ulink_classes [String] space separated list of classes for the "x" link
+    # @param tag [String] HTML tag to use for the html generated, defaults to and `a` tag
     # @param link_content [Block] block of code for the link content
     # @return [String] hidden field and link tag
-    def link_to_remove_nested(form, link_text: 'X', fields_wrapper_selector: nil, undo_link_timeout: nil, undo_link_text: 'Undo', undo_link_classes: '', link_classes: '', &link_content)
+    def link_to_remove_nested(form, link_text: 'X', fields_wrapper_selector: nil, undo_link_timeout: nil, undo_link_text: 'Undo', undo_link_classes: '', link_classes: '', tag: 'a', &link_content)
       data = {
         'fields-wrapper-selector': fields_wrapper_selector,
         'undo-timeout': undo_link_timeout,
@@ -65,10 +68,12 @@ module VanillaNested
       capture do
         concat form.hidden_field(:_destroy, value: 0)
         concat(
-          if block_given?
-            link_to('#', class: classes, data: data, &link_content)
-          else
-            link_to(link_text.html_safe, '#', class: classes, data: data)
+          content_tag(tag, class: classes, data: data) do
+            if block_given?
+              yield link_content
+            else
+              link_text.html_safe
+            end
           end
         )
       end

--- a/test/VanillaNestedTests/app/controllers/users_controller.rb
+++ b/test/VanillaNestedTests/app/controllers/users_controller.rb
@@ -3,4 +3,9 @@ class UsersController < ApplicationController
     @user = User.new
     @user.pets.build
   end
+
+  def new_with_custom_link_tag
+    @user = User.new
+    @user.pets.build
+  end
 end

--- a/test/VanillaNestedTests/app/views/users/_form_with_custom_link_tag.html.erb
+++ b/test/VanillaNestedTests/app/views/users/_form_with_custom_link_tag.html.erb
@@ -1,0 +1,14 @@
+<%= form_for user do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+
+  <%= link_to_add_nested(form, :pets, '#pets', tag: 'span', partial: 'pet_fields_with_custom_link_tag') do %>
+    <span><span>Add Pet</span></span>
+  <% end %>
+  <h1>Pets</h1>
+  <div id='pets'>
+    <%= form.fields_for :pets do |pet_f| %>
+      <%= render 'pet_fields_with_custom_link_tag', form: pet_f %>
+    <% end %>
+  </div>
+<% end %>

--- a/test/VanillaNestedTests/app/views/users/_pet_fields_with_custom_link_tag.html.erb
+++ b/test/VanillaNestedTests/app/views/users/_pet_fields_with_custom_link_tag.html.erb
@@ -1,0 +1,11 @@
+<div class="pet-fields">
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.label :color %>
+  <%= form.text_field :color %>
+  <%= link_to_remove_nested(form, tag: 'div') do %>
+    <span>
+      <span>X</span>
+    </span>
+  <% end %>
+</div>

--- a/test/VanillaNestedTests/app/views/users/index.html.erb
+++ b/test/VanillaNestedTests/app/views/users/index.html.erb
@@ -1,1 +1,2 @@
 <%= link_to 'New User', new_user_path %>
+<%= link_to 'New User with custom tags', new_with_custom_link_tag_users_path %>

--- a/test/VanillaNestedTests/app/views/users/new_with_custom_link_tag.html.erb
+++ b/test/VanillaNestedTests/app/views/users/new_with_custom_link_tag.html.erb
@@ -1,0 +1,2 @@
+<%= render partial: 'form_with_custom_link_tag', locals: {user: @user} %>
+<%= link_to 'Back', users_path %>

--- a/test/VanillaNestedTests/config/routes.rb
+++ b/test/VanillaNestedTests/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :users
+  resources :users do
+    collection do
+      get :new_with_custom_link_tag
+    end
+  end
 end

--- a/test/VanillaNestedTests/test/system/vanilla_nested_test.rb
+++ b/test/VanillaNestedTests/test/system/vanilla_nested_test.rb
@@ -57,4 +57,30 @@ class VanillaNestedTest < ApplicationSystemTestCase
     assert_selector '.pet-fields', count: 3
     assert_selector 'span', text: 'Limit reached', count: 1
   end
+
+  test "accepts custom tags for link_to_add/remove_nested" do
+    visit new_with_custom_link_tag_users_path
+
+    assert_selector '#new_user'
+
+    assert_selector '.pet-fields', count: 1
+
+    within '.pet-fields:nth-of-type(1)' do
+      fill_in 'Name', with: 'Spike'
+    end
+
+    # wrapper is a SPAN tag
+    find('span.vanilla-nested-add', text: 'Add Pet').click
+
+    assert_selector '.pet-fields', count: 2
+
+    within '.pet-fields:nth-of-type(2)' do
+      fill_in 'Name', with: 'Marnie'
+    end
+
+    # wrapper is a DIV tag
+    within '.pet-fields:nth-of-type(1)' do
+      find('div.vanilla-nested-remove', text: 'X').click
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the `tag: ` keyword argument for `link_to_add_nested` and `link_to_remove_nested` to customize the wrapper tag.

This closes https://github.com/arielj/vanilla-nested/issues/4