### PR TITLE
Add an 'added-by-vanilla-nested' class for fields added dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ You can run the tests following these commands:
 - rails test # unit tests
 - rails test:system # system tests
 
+> If you make changes in the JS files, you have to tell yarn to refresh the code inside the node_modules folder running `yarn upgrade vanilla-nested`, then clear webpacker cache with `rails webpacker:clobber`, and then restart the rails server or re-run the tests.
+
 # Changes from 1.0.0 to 1.1.0
 
 #### Change the method to infere the name of the partial
@@ -385,5 +387,10 @@ Play nicely with Turbolinks' `turbolinks:load` event.
 # Changes from 1.2.4 to 1.2.5
 
 License change from GPL to MIT
+
+# Changes for next release:
+
+- Custom generated HTML element tag
+- Extra class added to dynamically added fields
 
 > Remember to update both gem and package https://github.com/arielj/vanilla-nested/tree/master#update

--- a/app/assets/javascripts/vanilla_nested.js
+++ b/app/assets/javascripts/vanilla_nested.js
@@ -12,6 +12,7 @@
     const container = document.querySelector(data.containerSelector);
     const newHtml = data.html.replace(/_idx_placeholder_/g, Date.now());
 
+    // insert and store reference
     let inserted;
     switch (data.methodForInsert) {
       case ('append'):
@@ -23,6 +24,9 @@
         inserted = container.firstElementChild;
         break;
     }
+
+    // add a class to show it was added dynamically
+    inserted.classList.add('added-by-vanilla-nested');
 
     _dispatchEvent(container, 'vanilla-nested:fields-added', element, {added: inserted})
 

--- a/test/VanillaNestedTests/test/system/vanilla_nested_test.rb
+++ b/test/VanillaNestedTests/test/system/vanilla_nested_test.rb
@@ -7,7 +7,8 @@ class VanillaNestedTest < ApplicationSystemTestCase
 
     assert_selector '#new_user'
 
-    assert_selector '.pet-fields', count: 1
+    # one field, not added by vanilla-nested
+    assert_selector '.pet-fields:not(.added-by-vanilla-nested)', count: 1
 
     within '.pet-fields:nth-of-type(1)' do
       fill_in 'Name', with: 'Spike'
@@ -17,6 +18,9 @@ class VanillaNestedTest < ApplicationSystemTestCase
     find('a.vanilla-nested-add', text: 'Add Pet').click
 
     assert_selector '.pet-fields', count: 2
+    # one added and one not added by vanilla-nested
+    assert_selector '.pet-fields:not(.added-by-vanilla-nested)', count: 1
+    assert_selector '.pet-fields.added-by-vanilla-nested', count: 1
 
     within '.pet-fields:nth-of-type(2)' do
       fill_in 'Name', with: 'Marnie'


### PR DESCRIPTION
This PR addsan extra class to fields added dynamically, so it's easier to differenciate them from the fields that are rendered in the server.

This closes https://github.com/arielj/vanilla-nested/issues/6