### PR TITLE
Remove HTML for removed elements, add more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ You can run the tests following these commands:
 - rails test # unit tests
 - rails test:system # system tests
 
-> If you make changes in the JS files, you have to tell yarn to refresh the code inside the node_modules folder running `yarn upgrade vanilla-nested`, then clear webpacker cache with `rails webpacker:clobber`, and then restart the rails server or re-run the tests.
+> If you make changes in the JS files, you have to tell yarn to refresh the code inside the node_modules folder running `./bin/update-gem` (or `yarn upgrade vanilla-nested` and `rails webpacker:clobber`), and then restart the rails server or re-run the tests.
 
 # Changes from 1.0.0 to 1.1.0
 

--- a/app/assets/javascripts/vanilla_nested.js
+++ b/app/assets/javascripts/vanilla_nested.js
@@ -69,7 +69,13 @@
   // Hides an element, mainly the wrapper of a group of fields
   // "wrapper" is the wrapper of the link to remove fields
   function hideWrapper(wrapper) {
-    wrapper.style.display = 'none';
+    if (wrapper.classList.contains('added-by-vanilla-nested')) {
+      wrapper.remove();
+    } else {
+      const destroyInput = wrapper.querySelector('[name$="[_destroy]"');
+      wrapper.innerHTML = '';
+      wrapper.insertAdjacentElement('afterbegin', destroyInput);
+    }
   }
 
   // Unhides the children given a fields wrapper

--- a/test/VanillaNestedTests/app/controllers/users_controller.rb
+++ b/test/VanillaNestedTests/app/controllers/users_controller.rb
@@ -1,10 +1,16 @@
 class UsersController < ApplicationController
+  before_action :new_user
   def new
-    @user = User.new
-    @user.pets.build
   end
 
   def new_with_custom_link_tag
+  end
+
+  def new_with_undo
+  end
+
+  private
+  def new_user
     @user = User.new
     @user.pets.build
   end

--- a/test/VanillaNestedTests/app/views/users/_form_with_undo.html.erb
+++ b/test/VanillaNestedTests/app/views/users/_form_with_undo.html.erb
@@ -1,0 +1,14 @@
+<%= form_for user do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+
+  <%= link_to_add_nested(form, :pets, '#pets', partial: 'pet_fields_with_undo') do %>
+    <span><span>Add Pet</span></span>
+  <% end %>
+  <h1>Pets</h1>
+  <div id='pets'>
+    <%= form.fields_for :pets do |pet_f| %>
+      <%= render 'pet_fields_with_undo', form: pet_f %>
+    <% end %>
+  </div>
+<% end %>

--- a/test/VanillaNestedTests/app/views/users/_pet_fields_with_undo.html.erb
+++ b/test/VanillaNestedTests/app/views/users/_pet_fields_with_undo.html.erb
@@ -1,0 +1,11 @@
+<div class="pet-fields">
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.label :color %>
+  <%= form.text_field :color %>
+  <%= link_to_remove_nested(form, undo_link_timeout: 400) do %>
+    <span>
+      <span>X</span>
+    </span>
+  <% end %>
+</div>

--- a/test/VanillaNestedTests/app/views/users/index.html.erb
+++ b/test/VanillaNestedTests/app/views/users/index.html.erb
@@ -1,2 +1,5 @@
 <%= link_to 'New User', new_user_path %>
+<br />
 <%= link_to 'New User with custom tags', new_with_custom_link_tag_users_path %>
+<br />
+<%= link_to 'New User with undo', new_with_undo_users_path %>

--- a/test/VanillaNestedTests/app/views/users/new_with_undo.html.erb
+++ b/test/VanillaNestedTests/app/views/users/new_with_undo.html.erb
@@ -1,0 +1,2 @@
+<%= render partial: 'form_with_undo', locals: {user: @user} %>
+<%= link_to 'Back', users_path %>

--- a/test/VanillaNestedTests/bin/update-gem
+++ b/test/VanillaNestedTests/bin/update-gem
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+yarn upgrade vanilla-nested
+rails webpacker:clobber

--- a/test/VanillaNestedTests/config/routes.rb
+++ b/test/VanillaNestedTests/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :users do
     collection do
       get :new_with_custom_link_tag
+      get :new_with_undo
     end
   end
 end

--- a/test/VanillaNestedTests/test/system/vanilla_nested_test.rb
+++ b/test/VanillaNestedTests/test/system/vanilla_nested_test.rb
@@ -33,7 +33,10 @@ class VanillaNestedTest < ApplicationSystemTestCase
 
     # first pet is hidden
     assert_selector '.pet-fields', count: 1, visible: :hidden do |wrapper|
-      assert_equal '1', wrapper.find('[name$="[_destroy]"]', visible: :hidden).value
+      assert_equal 1, wrapper.all('*', visible: :hidden).length
+      destroy = wrapper.all('*', visible: :hidden).first
+      assert_match /\[_destroy\]\z/, destroy.native.attribute('name')
+      assert_equal '1', destroy.value
     end
 
     # second pet is visible
@@ -41,6 +44,13 @@ class VanillaNestedTest < ApplicationSystemTestCase
       # verify it's the second one
       assert_equal 'Marnie', wrapper.first('input').value
     end
+
+    within '.pet-fields:nth-of-type(2)' do
+      find('a.vanilla-nested-remove', text: 'X').click
+    end
+
+    # second pet is not there anymore
+    assert_selector '.pet-fields', count: 1, visible: :hidden
   end
 
   test "emits an event when the association limit is reached" do
@@ -86,5 +96,63 @@ class VanillaNestedTest < ApplicationSystemTestCase
     within '.pet-fields:nth-of-type(1)' do
       find('div.vanilla-nested-remove', text: 'X').click
     end
+  end
+
+  test "can undo" do
+    visit new_with_undo_users_path
+
+    assert_selector '#new_user'
+
+    assert_selector '.pet-fields', count: 1
+
+    within '.pet-fields:nth-of-type(1)' do
+      fill_in 'Name', with: 'Spike'
+    end
+
+    find('.vanilla-nested-add', text: 'Add Pet').click
+
+    assert_selector '.pet-fields', count: 2
+
+    # test with fields added dynamically
+    within '.pet-fields:nth-of-type(2)' do
+      assert_selector '.vanilla-nested-undo', text: 'Undo', count: 0
+      find('.vanilla-nested-remove', text: 'X').click
+
+      # added the Undo button
+      assert_selector '.vanilla-nested-undo', text: 'Undo', count: 1
+
+      # click undo to stop the removal
+      find('.vanilla-nested-undo', text: 'Undo').click()
+      assert_selector '.vanilla-nested-undo', text: 'Undo', count: 0
+
+      # click to remove for real
+      find('.vanilla-nested-remove', text: 'X').click
+    end
+
+    sleep(0.5) # undo timeout is configured as 400ms
+
+    assert_selector '.pet-fields', count: 1
+    assert_selector '.pet-fields', visible: :hidden, count: 0
+    
+    # test with fields rendered server side
+    within '.pet-fields:nth-of-type(1)' do
+      assert_selector '.vanilla-nested-undo', text: 'Undo', count: 0
+      find('.vanilla-nested-remove', text: 'X').click
+
+      # added the Undo button
+      assert_selector '.vanilla-nested-undo', text: 'Undo', count: 1
+
+      # click undo to stop the removal
+      find('.vanilla-nested-undo', text: 'Undo').click()
+      assert_selector '.vanilla-nested-undo', text: 'Undo', count: 0
+
+      # click to remove for real
+      find('.vanilla-nested-remove', text: 'X').click
+    end
+
+    sleep(0.5) # undo timeout is configured as 400ms
+
+    assert_selector '.pet-fields', count: 0
+    assert_selector '.pet-fields', visible: :hidden, count: 1
   end
 end


### PR DESCRIPTION
This PR fixes https://github.com/arielj/vanilla-nested/issues/5 by removing the actual HTML after removing elements.

- If the element was added by vanilla-nested, when removed it removes it completely.
- If the element was rendered serverside, when removed it clears the content but leaves the required `[_destroy]` hidden input
- I added some tests to make sure this also works in combination with the `Undo` feature
