### PR TITLE
Count only non-destroyed children to emit the limit reached event

### DIFF
--- a/app/assets/javascripts/vanilla_nested.js
+++ b/app/assets/javascripts/vanilla_nested.js
@@ -36,7 +36,7 @@
 
     // dispatch an event if we reached the limit configured on the model
     if (data.limit) {
-      let nestedElements = container.children.length;
+      let nestedElements = container.querySelectorAll('[name$="[_destroy]"][value="0"]').length;
       if (nestedElements >= data.limit)
         _dispatchEvent(container, 'vanilla-nested:fields-limit-reached', element)
     }

--- a/test/VanillaNestedTests/app/views/users/_form.html.erb
+++ b/test/VanillaNestedTests/app/views/users/_form.html.erb
@@ -7,6 +7,7 @@
   <% end %>
   <h1>Pets</h1>
   <div id='pets'>
+    <p>The limit is 3, configured in the model:</p>
     <%= form.fields_for :pets do |pet_f| %>
       <%= render 'pet_fields', form: pet_f %>
     <% end %>


### PR DESCRIPTION
The previous implementation was too basic only using the number of children that the wrapper had to calculate if the accepts_nested_attributes_for limit was reached. It was a problem since it was counting destroyed elements and also any other extra html element that was a direct child of the wrapper.

The new implementation counts the number of `[_destroy]` hidden fields with value of `0`, that's the correct amount.

This closes https://github.com/arielj/vanilla-nested/issues/8