### PR TITLE
fix undeclared variables in JS

### DIFF
--- a/app/assets/javascripts/vanilla_nested.js
+++ b/app/assets/javascripts/vanilla_nested.js
@@ -53,7 +53,8 @@
 
     const data = element.dataset;
     let wrapper = element.parentElement;
-    if (sel = data.fieldsWrapperSelector) wrapper = element.closest(sel);
+    const sel = data.fieldsWrapperSelector;
+    if (sel) wrapper = element.closest(sel);
 
     if (data.undoTimeout) {
       hideFieldsWithUndo(wrapper, element);
@@ -129,7 +130,8 @@
     const undo = document.createElement('A');
 
     undo.classList.add('vanilla-nested-undo');
-    if (classes = data.undoLinkClasses)
+    const classes = data.undoLinkClasses;
+    if (classes)
       undo.classList.add(...classes.split(' '));
 
     undo.innerText = data.undoText;


### PR DESCRIPTION
This PR fixes two places in the JS file that have undeclared variables. 

When compiling the JS file with a bundler that adds ```strict mode``` at the top, the browser will issue an error due to undeclared variables.