### PR TITLE
🐛 Treating synthetic `PointerEvent` on `removeVanillaNestedFields`

### DIFF
--- a/app/assets/javascripts/vanilla_nested.js
+++ b/app/assets/javascripts/vanilla_nested.js
@@ -41,7 +41,14 @@
 
   // Removes the fields or hides them until the undo timer times out
   // "event" is the click event of the link created by the rails helper
-  window.removeVanillaNestedFields = function(element) {
+  window.removeVanillaNestedFields = function(elementOrEvent) {
+    let element;
+    if (elementOrEvent.srcElement) {
+      element = elementOrEvent.srcElement;
+    } else {
+      element = elementOrEvent
+    }
+
     if (!element.classList.contains('vanilla-nested-remove'))
       element = element.closest('.vanilla-nested-remove')
 


### PR DESCRIPTION
Hi there 👋 

This is a great library, thanks for maintaining it!

I faced the same issue as #47 when using `vanilla-nested` with Turbo, and pointing my gem to the `main` branch of the repo solved it (kudos for the fix).

However, it seems that the changes [here](https://github.com/arielj/vanilla-nested/commit/d1577a01631d05c2673d5d4a30762d04ba87da29) introduced a edge-case error that I could trace to `removeVanillaNestedFields` receiving a synthetic `PointerEvent` instead of the expected `element` directly, under some circumstances. I added a small conditional with this PR to deal with both cases.

It seems that the synthetic event is only sent when removing nested fields added by clicking on the link generated by `link_to_add_nested`.

This may not be the best fix (and I may not understand the underlying reason this is happening), but I thought I'd send this PR and document the fix and the error anyway.

Tested on Chrome.

Thanks!

![CleanShot 2022-07-13 at 21 39 06](https://user-images.githubusercontent.com/3309021/178831286-289114fa-c6eb-43fb-9fc1-152daefb054b.gif)