### PR TITLE
Added partial_extra_params to link_to_add_nested helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ link_to_add_nested(form, :order_items, '#order-items', partial: 'my_partial')
 link_to_add_nested(form, :order_items, '#order-items', partial_form_variable: :ff)
 ```
 
+You can also pass more local variables to the partial by setting the partial_locals value.
+
+```Ruby
+link_to_add_nested(form, :order_items, '#order-items', partial_locals: { key: 'value' })
+``` 
+
 #### Tag
 
 The HTML tag that will be generated. An `<a>` tag by default.

--- a/lib/vanilla_nested/view_helpers.rb
+++ b/lib/vanilla_nested/view_helpers.rb
@@ -9,12 +9,12 @@ module VanillaNested
     # @param link_classes [String] space separated classes for the link tag
     # @param insert_method [:append, :prepend] tells javascript if the new fields should be appended or prepended to the container
     # @param partial_form_variable [String, Symbol] name of the variable that represents the form builder inside the fields partial
-    # @param partial_extra_params [Hash] extra params that should be send to the partial
+    # @param partial_locals [Hash] extra params that should be send to the partial
     # @param tag [String] HTML tag to use for the html generated, defaults to and `a` tag
     # @param link_content [Block] block of code for the link content
     # @param tag_attributes [Hash<attribute, value>] hash with attribute,value pairs for the html tag
     # @return [String] link tag
-    def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, partial_extra_params: {}, tag: 'a', tag_attributes: {}, &link_content)
+    def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, partial_locals: {}, tag: 'a', tag_attributes: {}, &link_content)
       association_class = form.object.class.reflections[association.to_s].klass
       object = association_class.new
 
@@ -22,7 +22,7 @@ module VanillaNested
 
       html = capture do
         form.fields_for association, object, child_index: '_idx_placeholder_' do |ff|
-          render partial: partial_name, locals: { partial_form_variable => ff }.merge(partial_extra_params)
+          render partial: partial_name, locals: { partial_form_variable => ff }.merge(partial_locals)
         end
       end
 

--- a/lib/vanilla_nested/view_helpers.rb
+++ b/lib/vanilla_nested/view_helpers.rb
@@ -9,11 +9,12 @@ module VanillaNested
     # @param link_classes [String] space separated classes for the link tag
     # @param insert_method [:append, :prepend] tells javascript if the new fields should be appended or prepended to the container
     # @param partial_form_variable [String, Symbol] name of the variable that represents the form builder inside the fields partial
+    # @param partial_extra_params [Hash] extra params that should be send to the partial
     # @param tag [String] HTML tag to use for the html generated, defaults to and `a` tag
     # @param link_content [Block] block of code for the link content
     # @param tag_attributes [Hash<attribute, value>] hash with attribute,value pairs for the html tag
     # @return [String] link tag
-    def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, tag: 'a', tag_attributes: {}, &link_content)
+    def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, partial_extra_params: {}, tag: 'a', tag_attributes: {}, &link_content)
       association_class = form.object.class.reflections[association.to_s].klass
       object = association_class.new
 
@@ -21,7 +22,7 @@ module VanillaNested
 
       html = capture do
         form.fields_for association, object, child_index: '_idx_placeholder_' do |ff|
-          render partial: partial_name, locals: { partial_form_variable => ff }
+          render partial: partial_name, locals: { partial_form_variable => ff }.merge(partial_extra_params)
         end
       end
 

--- a/test/VanillaNestedTests/Gemfile.lock
+++ b/test/VanillaNestedTests/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.8)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     public_suffix (4.0.6)
@@ -212,6 +214,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -241,4 +244,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.29
+   2.3.22

--- a/test/VanillaNestedTests/db/schema.rb
+++ b/test/VanillaNestedTests/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2021_02_20_015510) do
 
   create_table "pets", force: :cascade do |t|
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "name"
     t.string "color"
     t.index ["user_id"], name: "index_pets_on_user_id"


### PR DESCRIPTION
I have added a new parameter "partial_extra_params" on link_to_add_nested helper to permit user to send other extra parameters to the nested fields attributes.



In my example i have a form for the model Strategy with different Strategies::Rule for every typology. Now i can pass the typology value to an hidden field on rules attributes using partial_extra_params.

```ruby
# Models
class Strategy < ApplicationRecord
  has_many :strategies_rules, dependent: :destroy, class_name: 'Strategies::Rule'
  accepts_nested_attributes_for :strategies_rules, allow_destroy: true, limit: 100
end

class Strategies::Rule < ApplicationRecord
  enum typology: {
    tbd: 0,
    entry: 1,
    take_profit: 2,
    stop_loss: 3,
    trading_hours: 4
  }, _suffix: true

  belongs_to :strategy
end

# Controller
class StrategiesController < ApplicationController
  # ...
  
  def strategy_params
    params.require(:strategy).permit(:name, :default_pair_id, strategies_rules_attributes: %i[id name typology _destroy])
  end
end

# View helper
link_to_add_nested(form, :strategies_rules, "#rule-fields-#{dom_id(strategy)}-#{typology}",
  partial_extra_params: { typology: typology },
  link_text: 'Add rule' to typology,
)
```
