### PR TITLE
Create a nested form without an association

### DIFF
--- a/lib/vanilla_nested/view_helpers.rb
+++ b/lib/vanilla_nested/view_helpers.rb
@@ -35,7 +35,7 @@ module VanillaNested
       }
 
       nested_options = form.object.class.nested_attributes_options[association.to_sym]
-      data['limit'] = nested_options[:limit] if nested_options[:limit]
+      data['limit'] = nested_options[:limit] if nested_options && nested_options[:limit]
 
       attributes = tag_attributes
       attributes[:class] = "#{attributes.fetch(:class, '')} #{classes}"

--- a/lib/vanilla_nested/view_helpers.rb
+++ b/lib/vanilla_nested/view_helpers.rb
@@ -14,7 +14,7 @@ module VanillaNested
     # @param tag_attributes [Hash<attribute, value>] hash with attribute,value pairs for the html tag
     # @return [String] link tag
     def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, tag: 'a', tag_attributes: {}, &link_content)
-      association_class = association.classify.constantize
+      association_class = association.to_s.classify.constantize
       object = association_class.new
 
       partial_name = partial || "#{association_class.name.underscore}_fields"

--- a/lib/vanilla_nested/view_helpers.rb
+++ b/lib/vanilla_nested/view_helpers.rb
@@ -14,7 +14,7 @@ module VanillaNested
     # @param tag_attributes [Hash<attribute, value>] hash with attribute,value pairs for the html tag
     # @return [String] link tag
     def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, tag: 'a', tag_attributes: {}, &link_content)
-      association_class = form.object.class.reflections[association.to_s].klass
+      association_class = association.classify.constantize
       object = association_class.new
 
       partial_name = partial || "#{association_class.name.underscore}_fields"


### PR DESCRIPTION
This PR allows creating a nested form without needing to have the parent model associated with the child (to still benefit from all the js for unique use cases)
You still need the `accepted_nested_attributes` in the model
Not sure if you want to offer this option, feel free to close if not :)