### PR TITLE
support store_model type associations

### DIFF
--- a/lib/vanilla_nested/view_helpers.rb
+++ b/lib/vanilla_nested/view_helpers.rb
@@ -14,8 +14,8 @@ module VanillaNested
     # @param link_content [Block] block of code for the link content
     # @param tag_attributes [Hash<attribute, value>] hash with attribute,value pairs for the html tag
     # @return [String] link tag
-    def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, partial_locals: {}, tag: 'a', tag_attributes: {}, &link_content)
-      association_class = form.object.class.reflections[association.to_s].klass
+    def link_to_add_nested(form, association, container_selector, link_text: nil, link_classes: '', insert_method: :append, partial: nil, partial_form_variable: :form, partial_locals: {}, tag: 'a', tag_attributes: {}, klass: nil, &link_content)
+      association_class = klass || form.object.class.reflections[association.to_s].klass
       object = association_class.new
 
       partial_name = partial || "#{association_class.name.underscore}_fields"
@@ -36,7 +36,7 @@ module VanillaNested
       }
 
       nested_options = form.object.class.nested_attributes_options[association.to_sym]
-      data['limit'] = nested_options[:limit] if nested_options[:limit]
+      data['limit'] = nested_options[:limit] if nested_options and nested_options[:limit]
 
       attributes = tag_attributes
       attributes[:class] = "#{attributes.fetch(:class, '')} #{classes}"


### PR DESCRIPTION
Hi,

The [store_model](https://github.com/DmitryTsepelev/store_model) gem is a handy way to embed ActiveModel models inside other models and supports Arrays, which would be great to use with vanilla-nested. Unfortunately these relations are not exposed via reflection, so this breaks vanilla-nested's logic when creating the link.  

This PR allow specifying the `klass` manually in `link_to_add_nested` and does not fail if it can't derive the `limit` attribute from the reflected association.